### PR TITLE
Pop up on triptych showing LCS. Issue #3

### DIFF
--- a/visualisations/src/components/Triptych/Triptych.js
+++ b/visualisations/src/components/Triptych/Triptych.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { 
-  ProgressBar
+  ProgressBar,
+  OverlayTrigger,
+  Popover
 } from 'react-bootstrap';
 import styled from 'styled-components'
 import Radial from './../Radial/Radial'
@@ -47,6 +49,13 @@ const Right = styled.td`
   }
 `;
 
+const Pop = styled(Popover)`
+  font-size: 11px !important;
+  .popover-title {
+    font-size: 11px !important;
+  }
+`;
+
 /**
  * Triptych visualisation
  */
@@ -85,13 +94,26 @@ export default function Triptych({data}) {
               </Left>
               
               <Middle>
-                <Radial
-                  value={item.similarity}
-                  thickness="1"
-                  scale="9"
-                  valueBarColor="#070"
-                  style={{ margin: '0px 20px 15px 20px' }}
-                />
+                <OverlayTrigger 
+                  trigger={['hover', 'focus']}
+                  placement="top"
+                  overlay={
+                    item.lcs ? (
+                    <Pop key={$index} title="Least Common Subsuming" id="triptych-pop-over">
+                      {`${item.lcs.label} (${item.lcs.informationContent})`}
+                    </Pop>) : <Popover key={$index} id="triptych-pop-over" style={{ display: 'none' }} />
+                  }
+                >
+                <div style={{ cursor: 'pointer' }}>
+                    <Radial
+                      value={item.similarity}
+                      thickness="1"
+                      scale="9"
+                      valueBarColor="#070"
+                      style={{ margin: '0px 20px 15px 20px' }}
+                    />
+                  </div>
+                </OverlayTrigger>
               </Middle>
               
               <Right>

--- a/visualisations/src/containers/RedOctopus/data.triptych.js
+++ b/visualisations/src/containers/RedOctopus/data.triptych.js
@@ -27,6 +27,7 @@ export function generateTriptychQueryString(classedPhenoA, classedPhenoB, select
     newArr.push({
       [profileNameA]: { label: match.a.label, informationContent: parseFloat(match.a.IC).toFixed(2) },
       [profileNameB]: { label: match.b.label, informationContent: parseFloat(match.b.IC).toFixed(2) },
+      lcs: { label: match.lcs.label, informationContent: parseFloat(match.lcs.IC).toFixed(2) },
       similarity: calSimScore(match.a.IC, match.b.IC, match.lcs.IC, maxMaxIC)
     });
   })


### PR DESCRIPTION
Hover on sim-score will display a popover showing the LCS info.
This was discussed in the meeting on 24/5/2017 and in the following comment in #3:
https://github.com/genome-one/monarch/issues/3#issuecomment-300283155